### PR TITLE
fix: Bitwise AND of SubscribeOptions

### DIFF
--- a/include/sysrepo-cpp/Enum.hpp
+++ b/include/sysrepo-cpp/Enum.hpp
@@ -78,10 +78,10 @@ constexpr Enum implEnumBitOr(const Enum a, const Enum b)
 }
 
 template <typename Enum>
-constexpr bool implEnumBitAnd(const Enum a, const Enum b)
+constexpr Enum implEnumBitAnd(const Enum a, const Enum b)
 {
     using Type = std::underlying_type_t<Enum>;
-    return static_cast<Type>(a) & static_cast<Type>(b);
+    return static_cast<Enum>(static_cast<Type>(a) & static_cast<Type>(b));
 }
 
 constexpr SubscribeOptions operator|(const SubscribeOptions a, const SubscribeOptions b)
@@ -89,7 +89,7 @@ constexpr SubscribeOptions operator|(const SubscribeOptions a, const SubscribeOp
     return implEnumBitOr(a, b);
 }
 
-constexpr bool operator&(const SubscribeOptions a, const SubscribeOptions b)
+constexpr SubscribeOptions operator&(const SubscribeOptions a, const SubscribeOptions b)
 {
     return implEnumBitAnd(a, b);
 }


### PR DESCRIPTION
That's a bug fix of the bitwise AND operation of `SubscribeOptions` returning an enum rather than a bool.